### PR TITLE
fix(example-app): Set minSdkVersion version to 26

### DIFF
--- a/example-app/android/variables.gradle
+++ b/example-app/android/variables.gradle
@@ -1,5 +1,5 @@
 ext {
-    minSdkVersion = 22
+    minSdkVersion = 26
     compileSdkVersion = 34
     targetSdkVersion = 34
     androidxActivityVersion = '1.8.0'


### PR DESCRIPTION
The barcode library requires minSdkVersion 26 and was downgraded.
Looks like migrate command downgrades the minSdkVersion if the app has a newer version, will fix migrate command to not do that, but fixing the test app here as it doesn't build.
