### PR TITLE
fix(android-definitions):  native object not implemented in definitions

### DIFF
--- a/plugin/src/definitions.ts
+++ b/plugin/src/definitions.ts
@@ -61,10 +61,12 @@ export type CapacitorBarcodeScannerOptions = {
   scanButton?: boolean;
   scanText?: string;
   cameraDirection?: CapacitorBarcodeScannerCameraDirection;
-  scanOrientation?: CapacitorBarcodeScannerScanOrientation;
-  android?: {
-    scanningLibrary?: CapacitorBarcodeScannerAndroidScanningLibrary;
-  };
+  native?: { 
+    scanOrientation?: CapacitorBarcodeScannerScanOrientation; 
+    android?: { 
+      scanningLibrary?: CapacitorBarcodeScannerAndroidScanningLibrary; 
+    }; 
+  }
   web?: {
     showCameraSelection?: boolean;
     scannerFPS?: number;


### PR DESCRIPTION
- from the android plugin he tries to get scanOrientation and android/scanningLibrary from an object called native but doesn't declared in definitions actual definition cause a null

![Capture d'écran 2024-09-14 005552](https://github.com/user-attachments/assets/aae3467b-982c-4930-b2db-7d3defcf1bfd)
