### PR TITLE
docs:  add example usage to readme

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -47,6 +47,23 @@ The barcode scanner uses the camera on the device. Ensure you configure the Priv
 
 ---
 
+## Example
+
+```typescript
+import { CapacitorBarcodeScanner, CapacitorBarcodeScannerOptions, CapacitorBarcodeScannerTypeHintALLOption } from '@capacitor/barcode-scanner';
+
+const options: CapacitorBarcodeScannerOptions =
+{
+    hint: CapacitorBarcodeScannerTypeHintALLOption.ALL
+};
+
+const result = await CapacitorBarcodeScanner.scanBarcode(options);
+if (result?.ScanResult)
+{
+    console.log('Scanned barcode:', result.ScanResult);
+}
+```
+
 ## API
 
 <docgen-index>


### PR DESCRIPTION
The current docs do not have any example usage.

This example shows a basic implementation which will get most people off the ground running...