### PR TITLE
Fix Android camera crash by pinning osbarcode-android version to 1.1.3

### DIFF
--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -78,7 +78,7 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.aar', '*.jar'])
     //noinspection GradleDynamicVersion
-    implementation "com.github.outsystems:osbarcode-android:1.+@aar"
+    implementation "com.github.outsystems:osbarcode-android:1.1.3@aar"
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation 'androidx.activity:activity-ktx:1.8.2'


### PR DESCRIPTION
**Content:**
This pull request addresses a crash on Android when attempting to open the camera for QR code scanning using the `@capacitor/barcode-scanner` library. 

### Problem
Previously, the `android/build.gradle` file referenced the `osbarcode-android` dependency with a dynamic version (`1.+@aar`), which resulted in the app using version `1.1.5-dev2`. This led to a runtime error:
```
java.lang.NoSuchFieldError: No field Companion of type Landroidx/camera/lifecycle/ProcessCameraProvider$Companion;
```
This error caused the app to crash when trying to initialize the camera.

### Solution
The version of `osbarcode-android` has been set to `1.1.3`, which is confirmed to be compatible with Capacitor 6. This version change resolves the camera initialization error on Android.

Please review this change to ensure compatibility across all targeted environments.