### PR TITLE
chore(android): bump kotlin, gradle and aar versions

### DIFF
--- a/example-app/android/build.gradle
+++ b/example-app/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.1'
+        classpath 'com.android.tools.build:gradle:8.7.2'
         classpath 'com.google.gms:google-services:4.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/example-app/android/variables.gradle
+++ b/example-app/android/variables.gradle
@@ -1,15 +1,15 @@
 ext {
     minSdkVersion = 26
-    compileSdkVersion = 34
-    targetSdkVersion = 34
+    compileSdkVersion = 35
+    targetSdkVersion = 35
     androidxActivityVersion = '1.8.0'
-    androidxAppCompatVersion = '1.6.1'
+    androidxAppCompatVersion = '1.7.0'
     androidxCoordinatorLayoutVersion = '1.2.0'
     androidxCoreVersion = '1.12.0'
     androidxFragmentVersion = '1.6.2'
     coreSplashScreenVersion = '1.0.1'
     androidxWebkitVersion = '1.9.0'
-    junitVersion = '4.13.2'
+    junitVersion = '4.13.3'
     androidxJunitVersion = '1.1.5'
     androidxEspressoCoreVersion = '3.5.1'
     cordovaAndroidVersion = '10.1.1'

--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -6,7 +6,7 @@ ext {
 }
 
 buildscript {
-    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.9.22'
+    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.9.24'
     repositories {
         maven {
             url 'https://pkgs.dev.azure.com/OutSystemsRD/9e79bc5b-69b2-4476-9ca5-d67594972a52/_packaging/PublicArtifactRepository/maven/v1'
@@ -26,7 +26,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.1'
+        classpath 'com.android.tools.build:gradle:8.7.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -54,8 +54,8 @@ android {
         abortOnError false
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 }
 
@@ -78,20 +78,20 @@ repositories {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.aar', '*.jar'])
     //noinspection GradleDynamicVersion
-    implementation "com.github.outsystems:osbarcode-android:1.1.3@aar"
+    implementation "com.github.outsystems:osbarcode-android:1.2.0@aar"
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation 'androidx.activity:activity-ktx:1.8.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
+    implementation 'androidx.activity:activity-ktx:1.9.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     implementation 'com.google.zxing:core:3.4.1'
-    implementation 'com.google.mlkit:barcode-scanning:17.2.0'
-    implementation 'androidx.camera:camera-camera2:1.3.1'
-    implementation 'androidx.camera:camera-lifecycle:1.3.1'
-    implementation 'androidx.camera:camera-view:1.3.1'
-    implementation 'androidx.activity:activity-compose:1.8.2'
-    implementation 'androidx.compose.material3:material3:1.1.2'
-    implementation 'androidx.compose.material3:material3-window-size-class:1.1.2'
+    implementation 'com.google.mlkit:barcode-scanning:17.3.0'
+    implementation 'androidx.camera:camera-camera2:1.4.0'
+    implementation 'androidx.camera:camera-lifecycle:1.4.0'
+    implementation 'androidx.camera:camera-view:1.4.0'
+    implementation 'androidx.activity:activity-compose:1.9.3'
+    implementation 'androidx.compose.material3:material3:1.3.1'
+    implementation 'androidx.compose.material3:material3-window-size-class:1.3.1'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"


### PR DESCRIPTION
## Description
This PR bumps the kotlin and gradle versions, as well as the android's aar

fix for:
- https://github.com/ionic-team/capacitor-os-inappbrowser/pull/34