### PR TITLE
chore: use jdk 21

### DIFF
--- a/example-app/android/app/capacitor.build.gradle
+++ b/example-app/android/app/capacitor.build.gradle
@@ -2,8 +2,8 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_17
-      targetCompatibility JavaVersion.VERSION_17
+      sourceCompatibility JavaVersion.VERSION_21
+      targetCompatibility JavaVersion.VERSION_21
   }
 }
 

--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -59,6 +59,10 @@ android {
     }
 }
 
+kotlin {
+    jvmToolchain(21)
+}
+
 repositories {
     maven {
         url 'https://pkgs.dev.azure.com/OutSystemsRD/9e79bc5b-69b2-4476-9ca5-d67594972a52/_packaging/PublicArtifactRepository/maven/v1'


### PR DESCRIPTION
[RMET-3893](https://outsystemsrd.atlassian.net/browse/RMET-3893)
Cap 7 ::: Capacitor Plugins ::: Update to JDK 21

[RMET-3893]: https://outsystemsrd.atlassian.net/browse/RMET-3893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ