### PR TITLE
fix(web): ignore "No MultiFormat Readers" error

### DIFF
--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -122,7 +122,7 @@ export class CapacitorBarcodeScannerWeb extends WebPlugin implements CapacitorBa
       };
 
       const OSBarcodeWebScannerErrorCallback = (error: string) => {
-        const allowedErrors = ['No barcode or QR code detected', 'No MultiFormat Readers were able to detect the code'];
+        const allowedErrors = ['NotFoundException', 'No barcode or QR code detected', 'No MultiFormat Readers were able to detect the code'];
 
         if (!allowedErrors.find((e) => error.indexOf(e) !== -1)) {
           this.stopAndHideScanner();


### PR DESCRIPTION
Continuing the PR #62. The callback will ignore some errors as the reader is not ready yet, or something. The "NotFoundException" does not work on built code in desktop environment.

In mobile the error is "No barcode or QR code detected". In the desktop the error is "No MultiFormat Readers were able to detect the code". This change will ignore both of them and allows adding even more ignorable errors.

Fixes #50 