### PR TITLE
fix(web): enable back camera support in browser environment

### DIFF
--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -111,7 +111,7 @@ export class CapacitorBarcodeScannerWeb extends WebPlugin implements CapacitorBa
           focusMode: 'continuous',
           height: { min: 576, ideal: 1920 },
           deviceId: undefined,
-          facingMode: undefined,
+          facingMode: param.facingMode,
         },
       };
 


### PR DESCRIPTION
The Capacitor Barcode Scanner was defaulting to the front camera when running  in web environments. This change updates the camera selection logic to request  the rear-facing (environment) camera, ensuring proper functionality across  browsers like Chrome and Safari