### PR TITLE
chore(ci): upgrade GitHub action to v4/v5/v6 and Node.js to 22

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -11,9 +11,9 @@ runs:
   using: 'composite'
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 22
 
     - name: Install PNPM
       uses: pnpm/action-setup@v3
@@ -30,7 +30,7 @@ runs:
 
     - name: Setup PNPM cache
       id: cache-pnpm-store
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         STORE_PATH: ${{ env.STORE_PATH }}
       with:

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: 'macos-14'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Verify iOS + Android + Web'
@@ -35,7 +35,7 @@ jobs:
     runs-on: 'macos-14'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Build plugin'

--- a/.github/workflows/reusable_build-packages.yml
+++ b/.github/workflows/reusable_build-packages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}

--- a/.github/workflows/reusable_lint-packages.yml
+++ b/.github/workflows/reusable_lint-packages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'macos-14'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}

--- a/.github/workflows/reusable_release-npm.yml
+++ b/.github/workflows/reusable_release-npm.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_setup.yml
+++ b/.github/workflows/reusable_setup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}


### PR DESCRIPTION
- Upgrade actions/checkout v4 → v5 (https://github.com/actions/checkout/releases/tag/v5.0.0)
- Upgrade actions/setup-node v4 → v6 (https://github.com/actions/setup-node/releases/tag/v6.0.0)
- Upgrade actions/cache v3 → v4 (https://github.com/actions/cache/releases/tag/v4.3.0)
- Upgrade Node from 20 to 22 across all workflows