### PR TITLE
chore(ios): Point to stable capacitor-swift-pm

### DIFF
--- a/plugin/Package.swift
+++ b/plugin/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["CapacitorBarcodeScannerPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0-beta"),
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
         .package(url: "https://github.com/OutSystems/OSBarcodeLib-iOS.git", exact: "2.1.0")
     ],
     targets: [


### PR DESCRIPTION
We did this for all other plugins with Capacitor 8, but we seem to have missed this one.