### PR TITLE
chore(ci): Use Xcode 26

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -43,3 +43,8 @@ runs:
       if: inputs.skip-install-on-cache-hit == 'false' || (inputs.skip-install-on-cache-hit == 'true' && steps.cache-pnpm-store.cache-hit == 'false')
       shell: bash
       run: pnpm install
+    
+    - name: Set Xcode 26.0  # minimum support Xcode version by Capacitor 8
+      if: runner.os == 'macOS'
+      shell: bash
+      run: sudo xcode-select --switch /Applications/Xcode_26.0.app


### PR DESCRIPTION
Update CI to build iOS with Xcode 26.0, which is the same version that is used in Capacitor repo.

Previosuly was planning on using macos-26, but Xcode 26.0 [does not seem to come with iOS 26.0](https://github.com/actions/runner-images/blob/1783ba44e56676a5f629ef3667ab42e357da710b/images/macos/toolsets/toolset-15.json#L39) (recently changed), but [macos-15 Xcode 26.0 now comes with runtime](https://github.com/actions/runner-images/blob/1783ba44e56676a5f629ef3667ab42e357da710b/images/macos/toolsets/toolset-15.json#L39), so will stick with macos-15.