### PR TITLE
chore: fix running lint locally

### DIFF
--- a/plugin/eslint.config.cjs
+++ b/plugin/eslint.config.cjs
@@ -5,7 +5,7 @@ const prettierConfig = require('eslint-config-prettier');
 
 module.exports = [
   {
-    ignores: ['node_modules/**', 'dist/**', 'build/**', 'types/**', 'android/**', 'ios/**', 'eslint.config.*'],
+    ignores: ['node_modules/**', 'dist/**', 'build/**', '.build/**', 'types/**', 'android/**', 'ios/**', 'eslint.config.*'],
   },
   eslintjs.configs.recommended,
   {

--- a/plugin/src/web.ts
+++ b/plugin/src/web.ts
@@ -1,4 +1,3 @@
-/* eslint-env browser */
 import { WebPlugin } from "@capacitor/core";
 import type { Html5QrcodeResult } from "html5-qrcode";
 import { Html5Qrcode } from "html5-qrcode";


### PR DESCRIPTION
Fixes an issue where `.build` folders for iOS SPM were causing lint to break. Also removed an unnecessary eslint comment.