### PR TITLE
fix(android): only show camera preview after grating permission

### DIFF
--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -59,7 +59,7 @@ repositories {
 }
 
 dependencies {
-    implementation "io.ionic.libs:ionbarcode-android:2.1.0@aar"
+    implementation "io.ionic.libs:ionbarcode-android:2.1.1@aar"
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation 'androidx.activity:activity-ktx:1.11.0'


### PR DESCRIPTION
Basically a PR to update the native library with the fix from https://github.com/OutSystems/OSBarcodeLib-Android/pull/57

This shouldn't impact the current stable version, only the next major (because of https://github.com/ionic-team/capacitor-barcode-scanner/pull/134), but in theory could impact if developers have another plugin that transitively brings CameraX 1.6.X.

Feel free to test with the example-app in this repository.

At the very least, this PR stops some `SecurityException` logs from appearing in Logcat when requesting camera permission on Android.