### PR TITLE
ci: update node to 24 and update action versions

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -16,7 +16,7 @@ runs:
         node-version: 24
 
     - name: Install PNPM
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       id: pnpm-install
       with:
         version: 10

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -11,9 +11,9 @@ runs:
   using: 'composite'
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
-        node-version: 22
+        node-version: 24
 
     - name: Install PNPM
       uses: pnpm/action-setup@v4
@@ -30,7 +30,7 @@ runs:
 
     - name: Setup PNPM cache
       id: cache-pnpm-store
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       env:
         STORE_PATH: ${{ env.STORE_PATH }}
       with:

--- a/.github/workflows/basic-tests.yml
+++ b/.github/workflows/basic-tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Verify Android'
@@ -35,7 +35,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Verify iOS'
@@ -47,7 +47,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Prepare example app'
@@ -61,7 +61,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Prepare example app'
@@ -75,7 +75,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Prepare example app'

--- a/.github/workflows/reusable_build-packages.yml
+++ b/.github/workflows/reusable_build-packages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}

--- a/.github/workflows/reusable_lint-packages.yml
+++ b/.github/workflows/reusable_lint-packages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}

--- a/.github/workflows/reusable_release-npm.yml
+++ b/.github/workflows/reusable_release-npm.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_setup.yml
+++ b/.github/workflows/reusable_setup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN || github.token }}


### PR DESCRIPTION
Equivalent PR to ionic-team/capacitor#8557

Updates to macos runner and Xcode version are out-of-scope, to be done in other task / PR.

Internal JIRA Ref: https://outsystemsrd.atlassian.net/browse/RMET-4731