### PR TITLE
fix(android): only apply kotlin-android plugin if not already applied

### DIFF
--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -22,7 +22,9 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     namespace = "com.capacitorjs.barcodescanner"


### PR DESCRIPTION
Guards the explicit `apply plugin: 'kotlin-android'` behind a check for an existing `kotlin` extension. Under AGP 9, the Android/Kotlin toolchain can already register the `kotlin` extension before this plugin's build.gradle runs, so the unconditional apply fails with:

`Failed to apply plugin 'kotlin-android'. > Cannot add extension with name 'kotlin', as there is an extension already registered with that name.`
